### PR TITLE
Fix a typo'ed command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Kibana is provided.
 ### Manage Service
 
 If you are using an operating system with SystemD this service will be installed when you run `make install`.
-From there it can be managed with the systemctl tool (`systemctl start screepstats.service`).
+From there it can be managed with the systemctl tool (`systemctl start screepsstats.service`).
 
 For servers without systemd the `screepsstatsctl` service manager has been provided. It takes the commands
 `start`, `stop`, and `reset`. For security reasons this should be run as root (it will downgrade itself


### PR DESCRIPTION
Just a missing letter that caused me to pause for a second and need to look something up.
